### PR TITLE
add gunicorn to dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.9.10
+gunicorn==18.0
 wazimap==0.5.2


### PR DESCRIPTION
gunicorn was used to get a version of NepalMap running at http://nmd.centralus.cloudapp.azure.com/

It seems to be a standard way to run Django apps.