### PR TITLE
Add household size and male-to-female ratio

### DIFF
--- a/wazimap_np/templates/profile/sections/households.html
+++ b/wazimap_np/templates/profile/sections/households.html
@@ -9,6 +9,12 @@
             <div class="column-third">
                 {% include 'profile/_blocks/_stat_list.html' with stat=households.total_households stat_type='number' %}
             </div>
+            <div class="column-third">
+                {% include 'profile/_blocks/_stat_list.html' with stat=households.average_household_size decimals='true' %}
+            </div>
+            <div class="column-third">
+                {% include 'profile/_blocks/_stat_list.html' with stat=households.male_to_female_ratio decimals='true' %}
+            </div>
         </section>
         <section class="clearfix stat-row">
             <h2><a class="permalink" href="#household-construction-materials" id="household-construction-materials">Household construction materials <i class="fa fa-link"></i></a></h2>


### PR DESCRIPTION
This adds household size and male-to-female ratio. It uses other data that are already available to return the stats that are in the census-data `HOUSEHOLD_POPULATION_SIZE.csv` files.

Screenshot for Baitadi district:

![household-size](https://cloud.githubusercontent.com/assets/3824492/19503761/6c76b762-957b-11e6-9376-7b9fcb5996a5.png)

