### PR TITLE
Better explanation for male-to-female ratio

### DIFF
--- a/wazimap_np/profiles.py
+++ b/wazimap_np/profiles.py
@@ -268,7 +268,7 @@ def get_households_profile(geo_code, geo_level, session):
             'values': {'this': '{0:.2f}'.format(household_size)}
         },
         'male_to_female_ratio': {
-            'name': 'Male to female ratio',
+            'name': 'Men per 100 women',
             'values': {'this': '{0:.2f}'.format(male_female_ratio)}
         },
         'cooking_fuel_distribution': cooking_fuel_dict,


### PR DESCRIPTION
"Men per 100 women" is a better explanation of the stat than "Male to female ratio"

Current version:
![male-to-female-ratio](https://cloud.githubusercontent.com/assets/3824492/19583766/0ce12298-9705-11e6-8c17-b77ebd2c6ed8.png)


Updated version:
![men-per-100-women](https://cloud.githubusercontent.com/assets/3824492/19583752/fa8d6afc-9704-11e6-81bd-456e3d501d3c.png)
