### PR TITLE
Fix: Twitter logo not shown in mobile

### DIFF
--- a/wazimap_np/templates/_base.html
+++ b/wazimap_np/templates/_base.html
@@ -43,7 +43,7 @@
         {% endif %}
         <div class="header-buttons">
             {% if WAZIMAP.twitter %}
-            <a class="wide-only" href="https://twitter.com/{{ WAZIMAP.twitter }}" title="{{ WAZIMAP.twitter }} on Twitter" target="_blank"><i class="fa fa-2x fa-twitter"></i></a>
+            <a href="https://twitter.com/{{ WAZIMAP.twitter }}" title="{{ WAZIMAP.twitter }} on Twitter" target="_blank"><i class="fa fa-2x fa-twitter"></i></a>
             {% endif %}
         {% block header_branding %}
         {% endblock %}


### PR DESCRIPTION
The twitter logo in the header was not shown on small screens. 

It was the default intended behavior of Wazimap. This was enforced using a **"wide-only"** class that hides elements based on the screen size.

Removing this class from the logo section fixed it.