### PR TITLE
explain metadata in geojson files

### DIFF
--- a/wazimap_np/static/geo/README.md
+++ b/wazimap_np/static/geo/README.md
@@ -1,0 +1,11 @@
+# geojson file metadata
+
+Each geojson file must have an element like this in its properties:
+```
+{"code": "56", "name": "Humla", "geoid": "district-56", "level": "district"}
+```
+
+* "code" must match the value in `wazimap_geography.geo_code`
+* "name" must match the value in `wazimap_geography.name`
+* "level" must match the value in `wazimap_geography.geo_level`
+* "geoid" is a the location's level plus code with a hyphen between them


### PR DESCRIPTION
These seem to be the basics necessary for Wazimap to be able to use a geojson file. As we get ready to do VDC data, this may be useful. If there is a better place for this information, we can put it there instead.