### PR TITLE
Upgrade wazimap dependency to 0.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==1.9.10
 gunicorn==18.0
-wazimap==0.5.3
+wazimap==0.7.1


### PR DESCRIPTION
Updates the wazimap dependency to the lastest version. This includes the ability to "Support tables with raw values that are percentages" and that might be handy.