### PR TITLE
Standardize label formatting

### DIFF
--- a/wazimap_np/templates/profile/sections/demographics.html
+++ b/wazimap_np/templates/profile/sections/demographics.html
@@ -31,7 +31,7 @@
                     <div class="column-quarter"
                          id="chart-pie-demographics-pop_2031_dist"
                          data-stat-type="percentage"
-                         data-chart-title="Projected by Sex in 2031"></div>
+                         data-chart-title="Projected by sex in 2031"></div>
                 {% endif %}
             </section>
 

--- a/wazimap_np/templates/profile/sections/households.html
+++ b/wazimap_np/templates/profile/sections/households.html
@@ -38,7 +38,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#households-home-ownership"
-                       id="households-home-ownership">Home ownership <i
+                       id="households-home-ownership">Home Ownership <i
                         class="fa fa-link"></i></a></h2>
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.own_home stat_type='percentage' %}
@@ -50,7 +50,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#households-cooking-fuel"
-                       id="households-cooking-fuel">Main type of cooking fuel
+                       id="households-cooking-fuel">Main Type of Cooking Fuel
                     <i class="fa fa-link"></i></a></h2>
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.cooking_wood stat_type='percentage' %}
@@ -62,7 +62,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#households-lighting-fuel"
-                       id="households-lighting-fuel">Main type of lighting fuel
+                       id="households-lighting-fuel">Main Type of Lighting Fuel
                     <i class="fa fa-link"></i></a></h2>
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.lighting_electricity stat_type='percentage' %}
@@ -74,7 +74,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#households-drinking-water"
-                       id="households-drinking-water">Drinking water source <i
+                       id="households-drinking-water">Drinking Water Source <i
                         class="fa fa-link"></i></a></h2>
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.piped_tap stat_type='percentage' %}
@@ -86,7 +86,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#households-toilet-type"
-                       id="households-toilet-type">Household toilet type <i
+                       id="households-toilet-type">Household Toilet Type <i
                         class="fa fa-link"></i></a></h2>
                 <div class="column-third">
                     {% include 'profile/_blocks/_stat_list.html' with stat=households.flush_toilet stat_type='percentage' %}
@@ -98,7 +98,7 @@
             </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#household_facilities"
-                       id="household_facilities">Household facilities <i
+                       id="household_facilities">Household Facilities <i
                         class="fa fa-link"></i></a></h2>
                 <div class="column-full"
                      id="chart-column-households-household_facilities"

--- a/wazimap_np/templates/profile/sections/households.html
+++ b/wazimap_np/templates/profile/sections/households.html
@@ -22,7 +22,7 @@
                 <h2><a class="permalink"
                        href="#household-construction-materials"
                        id="household-construction-materials">Household
-                    construction materials <i class="fa fa-link"></i></a></h2>
+                    Construction Materials <i class="fa fa-link"></i></a></h2>
                 <div class="column-third"
                      id="chart-pie-households-foundation_type_distribution"
                      data-stat-type="scaled-percentage"


### PR DESCRIPTION
The labels are not consistent. This pull request adopts these standards:

- Title case for labels for sections
- Sentence case for labels for charts

Using the household construction materials section, here is an example. The section header, "Household Construction Materials," is title-cased. The chart headers, like "
Households by type of foundation," is sentence-cased.
![capital-vs-sentence-case-construction-materials](https://cloud.githubusercontent.com/assets/3824492/23832971/fa7602a4-070c-11e7-88e6-04c22c4ad992.png)


