### PR TITLE
Change header for population section from Demographics to Population.

### DIFF
--- a/wazimap_np/templates/profile/sections/demographics.html
+++ b/wazimap_np/templates/profile/sections/demographics.html
@@ -7,7 +7,7 @@
         </header>
         <div class="section-container">
             <section class="clearfix stat-row">
-                <h2><a class="permalink" href="#demographics">Demographics <i
+                <h2><a class="permalink" href="#demographics">Population <i
                         class="fa fa-link"></i></a></h2>
                 {% if demographics.is_vdc == True %}
                     <div class="column-quarter">


### PR DESCRIPTION
The population section had a header "Demographics," but I think "Population" is more accurate for what is labeled there.

If people prefer "Demographics," then we can leave it that way. Here are screenshots comparing the two:

Before:
![pop-header-before](https://cloud.githubusercontent.com/assets/3824492/23833101/07946172-070f-11e7-8eb0-9cda624f4051.png)

After:
![pop-header-after](https://cloud.githubusercontent.com/assets/3824492/23833102/0d684fc8-070f-11e7-9b94-dd9f74b57bfb.png)
