### PR TITLE
Update wazimap to 0.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==1.9.10
 gunicorn==18.0
-wazimap==0.7.1
+wazimap[gdal]==0.7.3
+GDAL==2.1.3
+Shapely==1.5.17


### PR DESCRIPTION
 and set GDAL and Shapely dependencies that need to be set with version 0.7.1 and higher.