### PR TITLE
Switch GDAL from 2.1.3 to 1.11.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.9.10
 gunicorn==18.0
 wazimap[gdal]==0.7.3
-GDAL==2.1.3
+GDAL==1.11.2
 Shapely==1.5.17


### PR DESCRIPTION
When deploying to the test server at nmtest.southcentralus.cloudapp.azure.com, GDAL 2.1.3 did not install cleanly. This rolls GDAL back to a version we know works and is already on the server. I updated the test server manually and confirmed 1.11.2 works.