### PR TITLE
remove unnecessary assignment of postgres table owner 'wazimap_np'

### DIFF
--- a/sql/age.sql
+++ b/sql/age.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: age_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: age_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE age_sex (
@@ -32,10 +32,8 @@ CREATE TABLE age_sex (
 );
 
 
-ALTER TABLE age_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: age_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: age_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY age_sex (geo_level, geo_code, "age in completed years", sex, total) FROM stdin WITH DELIMITER ',';
@@ -15339,7 +15337,7 @@ district,75,100,male,36
 
 
 --
--- Name: age_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: age_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY age_sex

--- a/sql/caste.sql
+++ b/sql/caste.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: caste; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: caste; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE caste (
@@ -31,10 +31,8 @@ CREATE TABLE caste (
 );
 
 
-ALTER TABLE caste OWNER TO wazimap_np;
-
 --
--- Data for Name: caste; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: caste; Type: TABLE DATA; Schema: public
 --
 
 COPY caste ("caste or ethnic group", total, geo_level, geo_code) FROM stdin WITH DELIMITER ',';
@@ -9998,7 +9996,7 @@ Sarki,7218,district,75
 
 
 --
--- Name: caste_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: caste_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY caste

--- a/sql/childbirthassistance.sql
+++ b/sql/childbirthassistance.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: childbirth_delivery_assistance; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: childbirth_delivery_assistance; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE childbirth_delivery_assistance (
@@ -31,10 +31,8 @@ CREATE TABLE childbirth_delivery_assistance (
 );
 
 
-ALTER TABLE childbirth_delivery_assistance OWNER TO wazimap_np;
-
 --
--- Data for Name: childbirth_delivery_assistance; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: childbirth_delivery_assistance; Type: TABLE DATA; Schema: public
 --
 
 COPY childbirth_delivery_assistance (geo_level, geo_code, "delivery type", total) FROM stdin WITH DELIMITER ',';
@@ -346,7 +344,7 @@ district,72,HEALTH_WORKER_AT_HOME,61
 
 
 --
--- Name: childbirth_delivery_assistance_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: childbirth_delivery_assistance_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY childbirth_delivery_assistance

--- a/sql/cookingfuel.sql
+++ b/sql/cookingfuel.sql
@@ -22,7 +22,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: maintypeofcookingfuel; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: maintypeofcookingfuel; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE maintypeofcookingfuel (
@@ -33,10 +33,8 @@ CREATE TABLE maintypeofcookingfuel (
 );
 
 
-ALTER TABLE maintypeofcookingfuel OWNER TO wazimap_np;
-
 --
--- Data for Name: maintypeofcookingfuel; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: maintypeofcookingfuel; Type: TABLE DATA; Schema: public
 --
 
 COPY maintypeofcookingfuel (geo_code, geo_level, "main type of cooking fuel" ,total) FROM stdin WITH DELIMITER ',';
@@ -32372,7 +32370,7 @@ NP,country,WOOD,3470224
 
 
 --
--- Name: maintypeofcookingfuel_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: maintypeofcookingfuel_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY maintypeofcookingfuel

--- a/sql/disability.sql
+++ b/sql/disability.sql
@@ -19,7 +19,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: disability_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: disability_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE disability_sex (
@@ -31,10 +31,8 @@ CREATE TABLE disability_sex (
 );
 
 
-ALTER TABLE disability_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: disability_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: disability_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY disability_sex (geo_code, geo_level, disability, sex, total) FROM stdin WITH DELIMITER ',';
@@ -73032,7 +73030,7 @@ NP,country,SPEECH_PROBLEM,male,33190
 
 
 --
--- Name: disability_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: disability_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY disability_sex

--- a/sql/drinkingwatersource.sql
+++ b/sql/drinkingwatersource.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: drinkingwatersource; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: drinkingwatersource; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE drinkingwatersource (
@@ -31,10 +31,8 @@ CREATE TABLE drinkingwatersource (
 );
 
 
-ALTER TABLE drinkingwatersource OWNER TO wazimap_np;
-
 --
--- Data for Name: drinkingwatersource; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: drinkingwatersource; Type: TABLE DATA; Schema: public
 --
 
 COPY drinkingwatersource (geo_code, geo_level, "drinking water source", total) FROM stdin WITH DELIMITER ',';
@@ -32370,7 +32368,7 @@ NP,country,UNCOVERED_WELL,255658
 
 
 --
--- Name: drinkingwatersource_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: drinkingwatersource_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY drinkingwatersource

--- a/sql/educationlevelpassed.sql
+++ b/sql/educationlevelpassed.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: educationlevelpassed_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: educationlevelpassed_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE educationlevelpassed_sex (
@@ -32,10 +32,8 @@ CREATE TABLE educationlevelpassed_sex (
 );
 
 
-ALTER TABLE educationlevelpassed_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: educationlevelpassed_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: educationlevelpassed_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY educationlevelpassed_sex (geo_code, geo_level, "education level passed", sex, total) FROM stdin WITH DELIMITER ',';
@@ -89253,7 +89251,7 @@ NP,country,SLC_AND_EQUIVALENT,male,932391
 
 
 --
--- Name: educationlevelpassed_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: educationlevelpassed_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY educationlevelpassed_sex

--- a/sql/electoral-bodies.sql
+++ b/sql/electoral-bodies.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: local_electoral_bodies; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: local_electoral_bodies; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE local_electoral_bodies (
@@ -31,10 +31,8 @@ CREATE TABLE local_electoral_bodies (
 );
 
 
-ALTER TABLE local_electoral_bodies OWNER TO wazimap_np;
-
 --
--- Data for Name: local_electoral_bodies; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: local_electoral_bodies; Type: TABLE DATA; Schema: public
 --
 
 COPY local_electoral_bodies (geo_level, geo_code, "local electoral body", total) FROM stdin WITH DELIMITER ',';
@@ -346,7 +344,7 @@ district,14,Mahanarpalika,0
 
 
 --
--- Name: local_electoral_bodies_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: local_electoral_bodies_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY local_electoral_bodies

--- a/sql/fieldofstudy.sql
+++ b/sql/fieldofstudy.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: fieldofstudy_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: fieldofstudy_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE fieldofstudy_sex (
@@ -32,10 +32,8 @@ CREATE TABLE fieldofstudy_sex (
 );
 
 
-ALTER TABLE fieldofstudy_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: fieldofstudy_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: fieldofstudy_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY fieldofstudy_sex (total, sex, "field of study", geo_level, geo_code) FROM stdin WITH DELIMITER ',';
@@ -2171,7 +2169,7 @@ COPY fieldofstudy_sex (total, sex, "field of study", geo_level, geo_code) FROM s
 
 
 --
--- Name: fieldofstudy_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: fieldofstudy_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY fieldofstudy_sex

--- a/sql/foundationtype.sql
+++ b/sql/foundationtype.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: foundationtype; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: foundationtype; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE foundationtype (
@@ -31,10 +31,8 @@ CREATE TABLE foundationtype (
 );
 
 
-ALTER TABLE foundationtype OWNER TO wazimap_np;
-
 --
--- Data for Name: foundationtype; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: foundationtype; Type: TABLE DATA; Schema: public
 --
 
 COPY foundationtype (geo_code, geo_level, "foundation type", total) FROM stdin WITH DELIMITER ',';
@@ -24288,7 +24286,7 @@ NP,country,WOODEN_PILLAR,1350151
 
 
 --
--- Name: foundationtype_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: foundationtype_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY foundationtype

--- a/sql/geography.sql
+++ b/sql/geography.sql
@@ -28,7 +28,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: wazimap_geography; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE wazimap_geography (
@@ -44,10 +44,8 @@ CREATE TABLE wazimap_geography (
 );
 
 
-ALTER TABLE wazimap_geography OWNER TO wazimap_np;
-
 --
--- Name: wazimap_geography_id_seq; Type: SEQUENCE; Schema: public; Owner: wazimap_np
+-- Name: wazimap_geography_id_seq; Type: SEQUENCE; Schema: public
 --
 
 CREATE SEQUENCE wazimap_geography_id_seq
@@ -58,10 +56,8 @@ CREATE SEQUENCE wazimap_geography_id_seq
     CACHE 1;
 
 
-ALTER TABLE wazimap_geography_id_seq OWNER TO wazimap_np;
-
 --
--- Name: wazimap_geography_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: wazimap_np
+-- Name: wazimap_geography_id_seq; Type: SEQUENCE OWNED BY; Schema: public
 --
 
 ALTER SEQUENCE wazimap_geography_id_seq OWNED BY wazimap_geography.id;
@@ -4131,12 +4127,12 @@ Tribhuwanbast,2273,2016,district,Tribhuwanbast,vdc,75
 \.
 
 --
--- Name: wazimap_geography_id_seq; Type: SEQUENCE SET; Schema: public; Owner: wazimap_np
+-- Name: wazimap_geography_id_seq; Type: SEQUENCE SET; Schema: public
 --
 
 SELECT pg_catalog.setval('wazimap_geography_id_seq', 1, false);
 --
--- Name: wazimap_geography_geo_level_9a5128d2_uniq; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_geo_level_9a5128d2_uniq; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY wazimap_geography
@@ -4144,35 +4140,35 @@ ALTER TABLE ONLY wazimap_geography
 
 
 --
--- Name: wazimap_geography_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY wazimap_geography
     ADD CONSTRAINT wazimap_geography_pkey PRIMARY KEY (id);
 
 --
--- Name: wazimap_geography_2fc6351a; Type: INDEX; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_2fc6351a; Type: INDEX; Schema: public; Tablespace:
 --
 
 CREATE INDEX wazimap_geography_2fc6351a ON wazimap_geography USING btree (long_name);
 
 
 --
--- Name: wazimap_geography_84cdc76c; Type: INDEX; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_84cdc76c; Type: INDEX; Schema: public; Tablespace:
 --
 
 CREATE INDEX wazimap_geography_84cdc76c ON wazimap_geography USING btree (year);
 
 
 --
--- Name: wazimap_geography_b068931c; Type: INDEX; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_b068931c; Type: INDEX; Schema: public; Tablespace:
 --
 
 CREATE INDEX wazimap_geography_b068931c ON wazimap_geography USING btree (name);
 
 
 --
--- Name: wazimap_geography_name_36b79089_like; Type: INDEX; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: wazimap_geography_name_36b79089_like; Type: INDEX; Schema: public; Tablespace:
 --
 
 CREATE INDEX wazimap_geography_name_36b79089_like ON wazimap_geography USING btree (name varchar_pattern_ops);

--- a/sql/homeownership.sql
+++ b/sql/homeownership.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: homeownership; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: homeownership; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE homeownership (
@@ -31,10 +31,8 @@ CREATE TABLE homeownership (
 );
 
 
-ALTER TABLE homeownership OWNER TO wazimap_np;
-
 --
--- Data for Name: homeownership; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: homeownership; Type: TABLE DATA; Schema: public
 --
 
 COPY homeownership (geo_code, geo_level, "home ownership", total) FROM stdin WITH DELIMITER ',';
@@ -16206,7 +16204,7 @@ NP,country,RENTED,694701
 
 
 --
--- Name: homeownership_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: homeownership_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY homeownership

--- a/sql/householdfacilities.sql
+++ b/sql/householdfacilities.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: householdfacilities; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: householdfacilities; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE householdfacilities (
@@ -31,10 +31,8 @@ CREATE TABLE householdfacilities (
 );
 
 
-ALTER TABLE householdfacilities OWNER TO wazimap_np;
-
 --
--- Data for Name: householdfacilities; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: householdfacilities; Type: TABLE DATA; Schema: public
 --
 
 COPY householdfacilities (geo_code, geo_level, "household facilities", total) FROM stdin WITH DELIMITER ',';
@@ -52575,7 +52573,7 @@ NP,country,TOTAL_HOUSEHOLDS,5423297
 
 
 --
--- Name: householdfacilities_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: householdfacilities_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY householdfacilities

--- a/sql/language.sql
+++ b/sql/language.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: language; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: language; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE language (
@@ -31,10 +31,8 @@ CREATE TABLE language (
 );
 
 
-ALTER TABLE language OWNER TO wazimap_np;
-
 --
--- Data for Name: language; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: language; Type: TABLE DATA; Schema: public
 --
 
 COPY language (geo_code,total,language,geo_level) FROM stdin WITH DELIMITER ',';
@@ -9162,7 +9160,7 @@ NP,9995,Nachhiring,country
 
 
 --
--- Name: language_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: language_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY language

--- a/sql/lightingfuel.sql
+++ b/sql/lightingfuel.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: lightingfuel; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: lightingfuel; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE lightingfuel (
@@ -31,10 +31,8 @@ CREATE TABLE lightingfuel (
 );
 
 
-ALTER TABLE lightingfuel OWNER TO wazimap_np;
-
 --
--- Data for Name: lightingfuel; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: lightingfuel; Type: TABLE DATA; Schema: public
 --
 
 COPY lightingfuel (geo_code, geo_level, "lighting fuel", total) FROM stdin WITH DELIMITER ',';
@@ -24288,7 +24286,7 @@ NP,country,SOLAR,403504
 
 
 --
--- Name: lightingfuel_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: lightingfuel_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY lightingfuel

--- a/sql/literacy.sql
+++ b/sql/literacy.sql
@@ -19,7 +19,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: literacy_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: literacy_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE literacy_sex (
@@ -31,10 +31,8 @@ CREATE TABLE literacy_sex (
 );
 
 
-ALTER TABLE literacy_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: literacy_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: literacy_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY literacy_sex (geo_code, geo_level, literacy, sex, total) FROM stdin WITH DELIMITER ',';
@@ -32370,7 +32368,7 @@ NP,country,NOT_STATED,male,8159
 
 
 --
--- Name: literacy_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: literacy_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY literacy_sex

--- a/sql/outerwalltype.sql
+++ b/sql/outerwalltype.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: outerwalltype; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: outerwalltype; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE outerwalltype (
@@ -31,10 +31,8 @@ CREATE TABLE outerwalltype (
 );
 
 
-ALTER TABLE outerwalltype OWNER TO wazimap_np;
-
 --
--- Data for Name: outerwalltype; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: outerwalltype; Type: TABLE DATA; Schema: public
 --
 
 COPY outerwalltype (geo_code, geo_level, "outer wall type", total) FROM stdin WITH DELIMITER ',';
@@ -28329,7 +28327,7 @@ NP,country,WOOD_PLANKS,287859
 
 
 --
--- Name: outerwalltype_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: outerwalltype_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY outerwalltype

--- a/sql/population_projection_2031.sql
+++ b/sql/population_projection_2031.sql
@@ -19,7 +19,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: population_projection_2031; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace: 
+-- Name: population_projection_2031; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE population_projection_2031 (
@@ -30,10 +30,8 @@ CREATE TABLE population_projection_2031 (
 );
 
 
-ALTER TABLE population_projection_2031 OWNER TO wazimap_np;
-
 --
--- Data for Name: population_projection_2031; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: population_projection_2031; Type: TABLE DATA; Schema: public
 --
 
 COPY population_projection_2031 (sex, geo_level, total, geo_code)  FROM stdin WITH DELIMITER ',';
@@ -193,7 +191,7 @@ male,country,16313189,NP
 
 
 --
--- Name: population_projection_2031_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace: 
+-- Name: population_projection_2031_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY population_projection_2031

--- a/sql/poverty.sql
+++ b/sql/poverty.sql
@@ -22,7 +22,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: poverty; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: poverty; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE poverty (
@@ -33,10 +33,8 @@ CREATE TABLE poverty (
 );
 
 
-ALTER TABLE poverty OWNER TO wazimap_np;
-
 --
--- Data for Name: poverty; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: poverty; Type: TABLE DATA; Schema: public
 --
 
 COPY poverty (geo_level, total, poverty, geo_code) FROM stdin WITH DELIMITER ',';
@@ -196,7 +194,7 @@ district,307085,NOT_IN_POVERTY,75
 
 
 --
--- Name: poverty_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: poverty_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY poverty

--- a/sql/rooftype.sql
+++ b/sql/rooftype.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: rooftype; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: rooftype; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE rooftype (
@@ -31,10 +31,8 @@ CREATE TABLE rooftype (
 );
 
 
-ALTER TABLE rooftype OWNER TO wazimap_np;
-
 --
--- Data for Name: rooftype; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: rooftype; Type: TABLE DATA; Schema: public
 --
 
 COPY rooftype (geo_code, geo_level, "roof type", total) FROM stdin WITH DELIMITER ',';
@@ -32370,7 +32368,7 @@ NP,country,WOOD_PLANKS,44069
 
 
 --
--- Name: rooftype_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: rooftype_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY rooftype

--- a/sql/safewater.sql
+++ b/sql/safewater.sql
@@ -19,7 +19,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: safewater; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace: 
+-- Name: safewater; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE safewater (
@@ -30,10 +30,8 @@ CREATE TABLE safewater (
 );
 
 
-ALTER TABLE safewater OWNER TO wazimap_np;
-
 --
--- Data for Name: safewater; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: safewater; Type: TABLE DATA; Schema: public
 --
 
 COPY safewater (geo_level, geo_code, "safe water", total) FROM stdin;
@@ -193,7 +191,7 @@ country	NP	YES	21846383
 
 
 --
--- Name: safewater_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace: 
+-- Name: safewater_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY safewater

--- a/sql/schoolattendance.sql
+++ b/sql/schoolattendance.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: schoolattendance_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: schoolattendance_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE schoolattendance_sex (
@@ -32,10 +32,8 @@ CREATE TABLE schoolattendance_sex (
 );
 
 
-ALTER TABLE schoolattendance_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: schoolattendance_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: schoolattendance_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY schoolattendance_sex (geo_code, geo_level, "school attendance", sex, total) FROM stdin WITH DELIMITER ',';
@@ -24283,7 +24281,7 @@ NP,country,SCHOOL_GOING,male,3711930
 
 
 --
--- Name: schoolattendance_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: schoolattendance_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY schoolattendance_sex

--- a/sql/simpletables/birthsathealthfacility.sql
+++ b/sql/simpletables/birthsathealthfacility.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: births_at_health_facility; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_at_health_facility; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE births_at_health_facility (
@@ -30,10 +30,8 @@ CREATE TABLE births_at_health_facility (
 );
 
 
-ALTER TABLE births_at_health_facility OWNER TO wazimap_np;
-
 --
--- Data for Name: births_at_health_facility; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: births_at_health_facility; Type: TABLE DATA; Schema: public
 --
 
 COPY births_at_health_facility (geo_level, geo_code, "percent deliveries at institutions") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ district,72,51.70
 
 
 --
--- Name: births_at_health_facility_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_at_health_facility_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY births_at_health_facility

--- a/sql/simpletables/birthswithnonsbaattendant.sql
+++ b/sql/simpletables/birthswithnonsbaattendant.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: births_with_non_sba_health_worker; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_with_non_sba_health_worker; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE births_with_non_sba_health_worker (
@@ -30,10 +30,8 @@ CREATE TABLE births_with_non_sba_health_worker (
 );
 
 
-ALTER TABLE births_with_non_sba_health_worker OWNER TO wazimap_np;
-
 --
--- Data for Name: births_with_non_sba_health_worker; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: births_with_non_sba_health_worker; Type: TABLE DATA; Schema: public
 --
 
 COPY births_with_non_sba_health_worker (geo_level, geo_code, "percent deliveries with non sba health worker") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ district,72,3.60
 
 
 --
--- Name: births_with_non_sba_health_worker_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_with_non_sba_health_worker_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY births_with_non_sba_health_worker

--- a/sql/simpletables/birthswithskilledattendant.sql
+++ b/sql/simpletables/birthswithskilledattendant.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: births_with_skilled_attendant; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_with_skilled_attendant; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE births_with_skilled_attendant (
@@ -30,10 +30,8 @@ CREATE TABLE births_with_skilled_attendant (
 );
 
 
-ALTER TABLE births_with_skilled_attendant OWNER TO wazimap_np;
-
 --
--- Data for Name: births_with_skilled_attendant; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: births_with_skilled_attendant; Type: TABLE DATA; Schema: public
 --
 
 COPY births_with_skilled_attendant (geo_level, geo_code, "percent deliveries with sba") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ district,72,51.50
 
 
 --
--- Name: births_with_skilled_attendant_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: births_with_skilled_attendant_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY births_with_skilled_attendant

--- a/sql/simpletables/childnourishment.sql
+++ b/sql/simpletables/childnourishment.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: child_nourishment; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: child_nourishment; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE child_nourishment (
@@ -30,10 +30,8 @@ CREATE TABLE child_nourishment (
 );
 
 
-ALTER TABLE child_nourishment OWNER TO wazimap_np;
-
 --
--- Data for Name: child_nourishment; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: child_nourishment; Type: TABLE DATA; Schema: public
 --
 
 COPY child_nourishment (geo_level, geo_code, "percent malnourished") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ country,NP,40.5
 
 
 --
--- Name: child_nourishment_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: child_nourishment_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY child_nourishment

--- a/sql/simpletables/income.sql
+++ b/sql/simpletables/income.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: per_capita_income; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: per_capita_income; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE per_capita_income (
@@ -30,10 +30,8 @@ CREATE TABLE per_capita_income (
 );
 
 
-ALTER TABLE per_capita_income OWNER TO wazimap_np;
-
 --
--- Data for Name: per_capita_income; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: per_capita_income; Type: TABLE DATA; Schema: public
 --
 
 COPY per_capita_income (geo_code, income, geo_level) FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ NP,1160,country
 
 
 --
--- Name: per_capita_income_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: per_capita_income_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY per_capita_income

--- a/sql/simpletables/lifeexpectancy.sql
+++ b/sql/simpletables/lifeexpectancy.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: lifeexpectancy; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: lifeexpectancy; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE lifeexpectancy (
@@ -30,10 +30,8 @@ CREATE TABLE lifeexpectancy (
 );
 
 
-ALTER TABLE lifeexpectancy OWNER TO wazimap_np;
-
 --
--- Data for Name: lifeexpectancy; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: lifeexpectancy; Type: TABLE DATA; Schema: public
 --
 
 COPY lifeexpectancy (geo_code, geo_level, years) FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ NP,country,68.80
 
 
 --
--- Name: lifeexpectancy_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: lifeexpectancy_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY lifeexpectancy

--- a/sql/simpletables/politicalparties.sql
+++ b/sql/simpletables/politicalparties.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: political_parties; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: political_parties; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE political_parties (
@@ -30,10 +30,8 @@ CREATE TABLE political_parties (
 );
 
 
-ALTER TABLE political_parties OWNER TO wazimap_np;
-
 --
--- Data for Name: political_parties; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: political_parties; Type: TABLE DATA; Schema: public
 --
 
 COPY political_parties (geo_level, geo_code, "number of registered political parties") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ district,14,23
 
 
 --
--- Name: political_parties_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: political_parties_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY political_parties

--- a/sql/simpletables/pollingplaces.sql
+++ b/sql/simpletables/pollingplaces.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: polling_places; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: polling_places; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE polling_places (
@@ -30,10 +30,8 @@ CREATE TABLE polling_places (
 );
 
 
-ALTER TABLE polling_places OWNER TO wazimap_np;
-
 --
--- Data for Name: polling_places; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: polling_places; Type: TABLE DATA; Schema: public
 --
 
 COPY polling_places (geo_level, geo_code, "number of polling places") FROM stdin WITH DELIMITER ',';
@@ -117,7 +115,7 @@ district,75,293
 
 
 --
--- Name: polling_places_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: polling_places_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY polling_places

--- a/sql/toilettype.sql
+++ b/sql/toilettype.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: toilettype; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: toilettype; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE toilettype (
@@ -31,10 +31,8 @@ CREATE TABLE toilettype (
 );
 
 
-ALTER TABLE toilettype OWNER TO wazimap_np;
-
 --
--- Data for Name: toilettype; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: toilettype; Type: TABLE DATA; Schema: public
 --
 
 COPY toilettype (geo_code, geo_level, "toilet type", total) FROM stdin WITH DELIMITER ',';
@@ -16206,7 +16204,7 @@ NP,country,ORDINARY_TOILET,1055862
 
 
 --
--- Name: toilettype_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: toilettype_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY toilettype

--- a/sql/voters.sql
+++ b/sql/voters.sql
@@ -20,7 +20,7 @@ SET default_tablespace = '';
 SET default_with_oids = false;
 
 --
--- Name: voters_sex; Type: TABLE; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: voters_sex; Type: TABLE; Schema: public; Tablespace:
 --
 
 CREATE TABLE voters_sex (
@@ -31,10 +31,8 @@ CREATE TABLE voters_sex (
 );
 
 
-ALTER TABLE voters_sex OWNER TO wazimap_np;
-
 --
--- Data for Name: voters_sex; Type: TABLE DATA; Schema: public; Owner: wazimap_np
+-- Data for Name: voters_sex; Type: TABLE DATA; Schema: public
 --
 
 COPY voters_sex (geo_level, geo_code, voter_sex, total) FROM stdin WITH DELIMITER ',';
@@ -270,7 +268,7 @@ district,14,third gender,0
 
 
 --
--- Name: voters_sex_pkey; Type: CONSTRAINT; Schema: public; Owner: wazimap_np; Tablespace:
+-- Name: voters_sex_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
 --
 
 ALTER TABLE ONLY voters_sex


### PR DESCRIPTION
This is some housekeeping to remove assignment of the wazimap_np user as the owner of the PostgreSQL tables. Removing this should make nepalmap more portable. For example, I believe this will make it easier to use Heroku or Dokku to deploy should we decide to switch to Heroku or try to build our own Dokku server on Azure.