### PR TITLE
Add docker compose support for development and production environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ node_modules/
 .idea/
 debug
 .vagrant
-/static/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ node_modules/
 debug
 .vagrant
 .DS_Store
+
+# Empty directories (for Compose mounts)
+static/*
+certs/*
+
+# Keep files
+!.keep

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+.DEFAULT_GOAL:=start
+SHELL:=/bin/bash
+
+ifeq ($(APP_ENV),)
+$(error -- APP_ENV needs to be set)
+endif
+
+# Pre-requisite ENVIRONMENT VARIABLES setup
+export HOST_USER_ID:=$(shell id -u)
+export HOST_GROUP_ID:=$(shell id -g)
+
+DOCKER_COMPOSE:=docker-compose -f compose.$(APP_ENV).yml
+
+# Targets for starting, stopping etc.
+
+.PHONY: build start stop tail-logs clean
+
+build:
+	$(DOCKER_COMPOSE) build
+
+start: build
+	$(DOCKER_COMPOSE) up -d
+
+stop:
+	$(DOCKER_COMPOSE) down
+
+stop-clean:
+	$(DOCKER_COMPOSE) down --rmi local --volumes --remove-orphans
+
+tail-logs:
+	$(if $(SERVICE_NAME), $(info -- Tailing logs for $(SERVICE_NAME)), $(info -- Tailing all logs, SERVICE_NAME not set.))
+	$(DOCKER_COMPOSE) logs -f $(SERVICE_NAME)
+
+# Targets for one-off tasks
+
+.PHONY: run-web web-bash
+
+DOCKER_COMPOSE_RUN_WEB:=$(DOCKER_COMPOSE) run --rm web
+
+run-web:
+	$(if $(CMD), $(DOCKER_COMPOSE_RUN_WEB) $(CMD), $(error -- CMD must be set))
+
+web-bash: CMD=/bin/bash
+web-bash: run-web
+
+# Cleanup etc.
+
+.PHONY: clean
+
+clean:
+	docker system prune --volumes -f

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SHELL:=/bin/bash
 
 ifeq ($(APP_ENV),)
 $(error -- APP_ENV needs to be set)
+else ifeq ($(APP_ENV),prod)
+APP_ENV_IS_PROD=true
 endif
 
 # Pre-requisite ENVIRONMENT VARIABLES setup
@@ -31,6 +33,13 @@ tail-logs:
 	$(if $(SERVICE_NAME), $(info -- Tailing logs for $(SERVICE_NAME)), $(info -- Tailing all logs, SERVICE_NAME not set.))
 	$(DOCKER_COMPOSE) logs -f $(SERVICE_NAME)
 
+# For deploying
+
+pull-latest:
+	$(if $(APP_ENV_IS_PROD), git checkout master && git pull, $(info -- Not pulling on $(APP_ENV) environment))
+
+deploy: stop pull-latest start
+
 # Targets for one-off tasks
 
 .PHONY: run-web web-bash
@@ -49,3 +58,4 @@ web-bash: run-web
 
 clean:
 	docker system prune --volumes -f
+	find static/. -maxdepth 1 \( -not -name '.gitignore' -not -name '.' \) -print0 | xargs -0 rm -rf

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-.DEFAULT_GOAL:=start
+.DEFAULT_GOAL:=help
 SHELL:=/bin/bash
 
 ifeq ($(APP_ENV),)
-$(error -- APP_ENV needs to be set)
+$(error -- APP_ENV needs to be set, eg. APP_ENV=dev make)
 else ifeq ($(APP_ENV),prod)
 APP_ENV_IS_PROD=true
 endif
@@ -17,19 +17,23 @@ DOCKER_COMPOSE:=docker-compose -f compose.$(APP_ENV).yml
 
 .PHONY: build start stop tail-logs clean
 
-build:
+help:  ## Display this help
+	$(info)
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ { printf " \033[36m%-10s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+build:  ## (Force) Build the docker images (automatically run by `make start`)
 	$(DOCKER_COMPOSE) build
 
-start: build
+start: build ## Start all the project service containers daemonised (Logs are tailed by a separate command)
 	$(DOCKER_COMPOSE) up -d
 
-stop:
+stop: ## Stop all the project service containers
 	$(DOCKER_COMPOSE) down
 
-stop-clean:
+stop-clean: ## Stop all the project service containers, cleanup project images, dangling/orphaned volumes
 	$(DOCKER_COMPOSE) down --rmi local --volumes --remove-orphans
 
-tail-logs:
+tail-logs: ## Tail the logs for the project service containers (Filtered via SERVICE_NAME, eg. make tail-logs SERVICE_NAME=worker)
 	$(if $(SERVICE_NAME), $(info -- Tailing logs for $(SERVICE_NAME)), $(info -- Tailing all logs, SERVICE_NAME not set.))
 	$(DOCKER_COMPOSE) logs -f $(SERVICE_NAME)
 
@@ -38,7 +42,7 @@ tail-logs:
 pull-latest:
 	$(if $(APP_ENV_IS_PROD), git checkout master && git pull, $(info -- Not pulling on $(APP_ENV) environment))
 
-deploy: stop pull-latest start
+deploy: stop pull-latest start ## Not intended for dev environment. Stops the services, Git pull the latest master & Start the services again
 
 # Targets for one-off tasks
 
@@ -46,16 +50,16 @@ deploy: stop pull-latest start
 
 DOCKER_COMPOSE_RUN_WEB:=$(DOCKER_COMPOSE) run --rm web
 
-run-web:
+run-web: ## Run a one-off command in a new web service container. Specify using CMD (eg. make run-web CMD=python manage.py collectstatic)
 	$(if $(CMD), $(DOCKER_COMPOSE_RUN_WEB) $(CMD), $(error -- CMD must be set))
 
-web-bash: CMD=/bin/bash
-web-bash: run-web
+bash-web: CMD=/bin/bash
+bash-web: run-web ## Spawn a bash shell for web service
 
 # Cleanup etc.
 
 .PHONY: clean
 
-clean:
+prune: ## Cleanup dangling/orphaned docker resources as well assets folder. Recommended to run every now and then to free up disk space etc.
 	docker system prune --volumes -f
 	find static/. -maxdepth 1 \( -not -name '.gitignore' -not -name '.' \) -print0 | xargs -0 rm -rf

--- a/README.md
+++ b/README.md
@@ -46,6 +46,68 @@ Start the server:
 python manage.py runserver
 ```
 
+# Docker based setup
+
+Using this setup, one can run the project inside docker containers. This make the environments lightweight, reproducible and portable.
+
+## Requirements
+
+Only the following things are required on your host machine. Nothing else needs to be installed.
+
+- GNU Make ( Version 4.0 and up )
+- Docker Engine ( Version 17.06 and hopefully upwards )
+- Docker Compose ( Version 1.14 and hopefully upwards )
+
+
+## Development environment
+
+All commands are provided as make targets via Makefile. One can use docker and docker-compose directly for running the services, but some helpers are provided for consistency.
+
+An application environment context (dev, prod) has to be set along with any of the `make ...` commands. You can either export this in your shell environment, or pass it as an argument to the make target.
+
+```
+# Start the development environment
+APP_ENV=dev make start
+
+# Watch the logs
+APP_ENV=dev make tail-logs
+
+# Watch the logs for a particular service
+APP_ENV=dev SERVICE_NAME=web make tail-logs
+
+# Stop all the services
+APP_ENV=dev make stop
+
+# Stop and cleanup volumes etc
+APP_ENV=dev make stop-clean
+
+# Get a bash terminal in the context of web service (runs in a new container)
+APP_ENV=dev make web-bash
+
+# Run any ad-hoc command in the context of web service (runs in a new container)
+APP_ENV=dev make run-web CMD="python ./manage.py migrate"
+```
+
+## Production environment
+
+This is very much similar to running the dev environment. Caddy is used instead of Nginx, because of it's automatic HTTPS certs and other easier-to-configure things. Some commands are added, else much of them are the same as above, expect for the `APP_ENV` context set to `prod`.
+
+NOTE: Check the comments in `compose.prod.yml` before running in production.
+
+```
+# Start the production environment
+APP_ENV=prod make start
+
+# Update the deploy (stops, pulls from git and starts again)
+APP_ENV=prod make deploy
+```
+
+## Cleanup
+
+Every now and then, make sure to run the following command to cleanup orphaned docker resources and other project artifacts.
+```
+APP_ENV=dev make clean
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Only the following things are required on your host machine. Nothing else needs 
 
 All commands are provided as make targets via Makefile. One can use docker and docker-compose directly for running the services, but some helpers are provided for consistency.
 
-An application environment context (dev, prod) has to be set along with any of the `make ...` commands. You can either export this in your shell environment, or pass it as an argument to the make target.
+An application environment context (dev, staging) has to be set along with any of the `make ...` commands. You can either export this in your shell environment, or pass it as an argument to the make target.
 
 ```
 # Start the development environment
@@ -88,18 +88,18 @@ APP_ENV=dev make web-bash
 APP_ENV=dev make run-web CMD="python ./manage.py migrate"
 ```
 
-## Production environment
+## Staging environment
 
-This is very much similar to running the dev environment. Caddy is used instead of Nginx, because of it's automatic HTTPS certs and other easier-to-configure things. Some commands are added, else much of them are the same as above, expect for the `APP_ENV` context set to `prod`.
+This is very much similar to running the dev environment. Caddy is used instead of Nginx, because of it's automatic HTTPS certs and other easier-to-configure things. Some commands are added, else much of them are the same as above, expect for the `APP_ENV` context set to `staging`.
 
-NOTE: Check the comments in `compose.prod.yml` before running in production.
+NOTE: Check the comments in `compose.staging.yml` before running in staging.
 
 ```
-# Start the production environment
-APP_ENV=prod make start
+# Start the staging environment
+APP_ENV=staging make start
 
 # Update the deploy (stops, pulls from git and starts again)
-APP_ENV=prod make deploy
+APP_ENV=staging make deploy
 ```
 
 ## Cleanup

--- a/README.md
+++ b/README.md
@@ -66,26 +66,8 @@ All commands are provided as make targets via Makefile. One can use docker and d
 An application environment context (dev, staging) has to be set along with any of the `make ...` commands. You can either export this in your shell environment, or pass it as an argument to the make target.
 
 ```
-# Start the development environment
-APP_ENV=dev make start
-
-# Watch the logs
-APP_ENV=dev make tail-logs
-
-# Watch the logs for a particular service
-APP_ENV=dev SERVICE_NAME=web make tail-logs
-
-# Stop all the services
-APP_ENV=dev make stop
-
-# Stop and cleanup volumes etc
-APP_ENV=dev make stop-clean
-
-# Get a bash terminal in the context of web service (runs in a new container)
-APP_ENV=dev make web-bash
-
-# Run any ad-hoc command in the context of web service (runs in a new container)
-APP_ENV=dev make run-web CMD="python ./manage.py migrate"
+# Get all the Makefile documentation
+APP_ENV=dev make help
 ```
 
 ## Staging environment
@@ -93,21 +75,6 @@ APP_ENV=dev make run-web CMD="python ./manage.py migrate"
 This is very much similar to running the dev environment. Caddy is used instead of Nginx, because of it's automatic HTTPS certs and other easier-to-configure things. Some commands are added, else much of them are the same as above, expect for the `APP_ENV` context set to `staging`.
 
 NOTE: Check the comments in `compose.staging.yml` before running in staging.
-
-```
-# Start the staging environment
-APP_ENV=staging make start
-
-# Update the deploy (stops, pulls from git and starts again)
-APP_ENV=staging make deploy
-```
-
-## Cleanup
-
-Every now and then, make sure to run the following command to cleanup orphaned docker resources and other project artifacts.
-```
-APP_ENV=dev make clean
-```
 
 # License
 

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,39 @@
+version: '3'
+
+services:
+
+  postgres:
+    image: library/postgres:9.5-alpine
+    environment:
+      POSTGRES_USER: wazimap_np
+      POSTGRES_PASSWORD: wazimap_np
+      POSTGRES_DB: wazimap_np
+
+  web:
+    build:
+      context: .
+      dockerfile: compose/web/Dockerfile
+    restart: always
+    command: wait-for-it postgres-host:5432 --strict --timeout=30 -- start-web
+    depends_on:
+      - postgres
+    links:
+      - postgres:postgres-host
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/usr/src/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      - HOST_USER_ID
+      - HOST_GROUP_ID
+      - APP_ENV
+      - POSTGRES_HOST=postgres-host
+      - POSTGRES_PORT=5432
+      - POSTGRES_USERNAME=wazimap_np
+      - POSTGRES_PASSWORD=wazimap_np
+      - POSTGRES_DATABASE=wazimap_np

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,63 @@
+version: '3'
+
+services:
+
+  postgres:
+    image: library/postgres:9.5-alpine
+    environment:
+      POSTGRES_USER: wazimap_np
+      POSTGRES_PASSWORD: wazimap_np
+      POSTGRES_DB: wazimap_np
+
+  web:
+    build:
+      context: .
+      dockerfile: ./compose/web/Dockerfile
+    restart: always
+    command: wait-for-it postgres-host:5432 --strict --timeout=30 -- start-web
+    depends_on:
+      - postgres
+    links:
+      - postgres:postgres-host
+    volumes:
+      - ./:/usr/src/app
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    environment:
+      - HOST_USER_ID
+      - HOST_GROUP_ID
+      - APP_ENV
+      - POSTGRES_HOST=postgres-host
+      - POSTGRES_PORT=5432
+      - POSTGRES_USERNAME=wazimap_np
+      - POSTGRES_PASSWORD=wazimap_np
+      - POSTGRES_DATABASE=wazimap_np
+
+  caddy:
+    build:
+      context: .
+      dockerfile: ./compose/caddy/Dockerfile
+    restart: always
+    entrypoint: wait-for-it web-host:8000 --strict --timeout=30 -- start-caddy
+    depends_on:
+      - web
+    links:
+      - web:web-host
+    volumes:
+      - ./compose/caddy/Caddyfile:/etc/Caddyfile
+      - ./compose/common/bin/wait-for-it:/usr/local/sbin/wait-for-it
+      - ./compose/caddy/bin/start-caddy:/usr/local/sbin/start-caddy
+      - ./certs:/etc/caddycerts
+      - ./static:/static
+    environment:
+      - CADDYPATH=/etc/caddycerts
+      - PROXY_HOST=web-host
+      - PROXY_PORT=8000
+      - HOST_NAME=localhost # Change to nepalmap.org once ready to use in production
+    ports:
+        - "0.0.0.0:80:80"
+        - "0.0.0.0:443:443"
+        - "2015:2015"       # Remove this port mapping once ready to use in production

--- a/compose.staging.yml
+++ b/compose.staging.yml
@@ -53,11 +53,12 @@ services:
       - ./certs:/etc/caddycerts
       - ./static:/static
     environment:
+      - APP_ENV
       - CADDYPATH=/etc/caddycerts
       - PROXY_HOST=web-host
       - PROXY_PORT=8000
-      - HOST_NAME=localhost # Change to nepalmap.org once ready to use in production
+      - HOST_NAME=staging.nepalmap.org # Change to staging server for nepalmap.org
+      - TLS_EMAIL=test@example.com     # Enter a email address here link to LetsEncrypt certs
     ports:
         - "0.0.0.0:80:80"
         - "0.0.0.0:443:443"
-        - "2015:2015"       # Remove this port mapping once ready to use in production

--- a/compose/caddy/Caddyfile
+++ b/compose/caddy/Caddyfile
@@ -1,0 +1,11 @@
+{$HOST_NAME}
+
+root /static
+
+proxy / {$PROXY_HOST}:{$PROXY_PORT} {
+    transparent
+}
+
+log stdout
+errors stdout
+gzip

--- a/compose/caddy/Caddyfile
+++ b/compose/caddy/Caddyfile
@@ -1,5 +1,7 @@
 {$HOST_NAME}
 
+tls {$TLS_EMAIL}
+
 root /static
 
 proxy / {$PROXY_HOST}:{$PROXY_PORT} {

--- a/compose/caddy/Dockerfile
+++ b/compose/caddy/Dockerfile
@@ -1,0 +1,3 @@
+FROM abiosoft/caddy:0.10.6
+
+RUN apk add --no-cache bash

--- a/compose/caddy/bin/start-caddy
+++ b/compose/caddy/bin/start-caddy
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eou pipefail
+
+exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout

--- a/compose/caddy/bin/start-caddy
+++ b/compose/caddy/bin/start-caddy
@@ -2,4 +2,11 @@
 
 set -eou pipefail
 
-exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout
+: ${APP_ENV?"APP_ENV not set. Aborting !"}
+
+if [ "$APP_ENV" = "prod" ]; then
+    exec /usr/bin/caddy --conf /etc/Caddyfile --log stdout
+else
+    # For staging etc. run the following, as it's not rate limited
+    exec /usr/bin/caddy -ca https://acme-staging.api.letsencrypt.org/directory --conf /etc/Caddyfile --log stdout
+fi

--- a/compose/common/bin/wait-for-it
+++ b/compose/common/bin/wait-for-it
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+#   https://github.com/vishnubob/wait-for-it
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi

--- a/compose/web/Dockerfile
+++ b/compose/web/Dockerfile
@@ -1,0 +1,35 @@
+FROM library/python:2.7.14-stretch
+
+ENV PYTHONUNBUFFERED="true" \
+    PATH="/usr/src/app/compose/web/bin:/usr/src/app/compose/common/bin:${PATH}" \
+    GOSU_VERSION="1.10"
+
+RUN set -exu \
+
+    # libgdal
+    && apt-get update \
+    && apt-get install -y libgdal-dev=2.1.2+dfsg-5 postgresql-client \
+    && rm -rf /var/lib/apt/lists/* \
+
+    # gosu for easy step down from root
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+
+    # make workdir
+    && mkdir -p /usr/src/app
+
+WORKDIR /usr/src/app
+
+COPY compose/web/requirements.txt /usr/src/app/requirements.txt
+RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt 
+
+COPY . /usr/src/app/
+
+ENTRYPOINT ["/usr/src/app/compose/web/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/compose/web/bin/start-web
+++ b/compose/web/bin/start-web
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eou pipefail
+
+: ${APP_ENV?"APP_ENV not set. Aborting !"}
+: ${POSTGRES_HOST?"POSTGRES_HOST not set. Aborting !"}
+: ${POSTGRES_PORT?"POSTGRES_PORT not set. Aborting !"}
+: ${POSTGRES_USERNAME?"POSTGRES_USERNAME not set. Aborting !"}
+: ${POSTGRES_PASSWORD?"POSTGRES_PASSWORD not set. Aborting !"}
+: ${POSTGRES_DATABASE?"POSTGRES_DATABASE not set. Aborting !"}
+
+# prepare environment variable for django settings
+export DATABASE_URL="postgresql://$POSTGRES_USERNAME:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DATABASE"
+
+# setup pgpassfile for psql non-interactive authentication
+export PGPASSWORD="$POSTGRES_PASSWORD"
+
+# Setup Simpletable entries
+cat sql/simpletables/*.sql | psql -w -U "$POSTGRES_USERNAME"  -h "$POSTGRES_HOST"
+
+# Migrate
+python ./manage.py migrate --no-input
+
+# Import data for tables
+cat sql/*.sql | psql -w -U "$POSTGRES_USERNAME" -h "$POSTGRES_HOST"
+
+# Start server
+if [ "$APP_ENV" = "prod" ]; then
+
+    export DJANGO_SETTINGS_MODULE="wazimap_np.settings"
+    python ./manage.py collectstatic --no-input
+    exec gunicorn wazimap.wsgi:application --worker-class sync --workers 4 --timeout 30 --log-file - --bind 0.0.0.0:8000 --name wazimap_np --chdir /usr/src/app
+
+else
+
+    exec python ./manage.py runserver 0.0.0.0:8000
+
+fi

--- a/compose/web/bin/start-web
+++ b/compose/web/bin/start-web
@@ -25,14 +25,14 @@ python ./manage.py migrate --no-input
 cat sql/*.sql | psql -w -U "$POSTGRES_USERNAME" -h "$POSTGRES_HOST"
 
 # Start server
-if [ "$APP_ENV" = "prod" ]; then
+if [ "$APP_ENV" = "dev" ]; then
+
+    exec python ./manage.py runserver 0.0.0.0:8000
+
+else
 
     export DJANGO_SETTINGS_MODULE="wazimap_np.settings"
     python ./manage.py collectstatic --no-input
     exec gunicorn wazimap.wsgi:application --worker-class sync --workers 4 --timeout 30 --log-file - --bind 0.0.0.0:8000 --name wazimap_np --chdir /usr/src/app
-
-else
-
-    exec python ./manage.py runserver 0.0.0.0:8000
 
 fi

--- a/compose/web/entrypoint.sh
+++ b/compose/web/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -eou pipefail
+
+: ${HOST_USER_ID?"Please set HOST_USER_ID environment variable. (Run 'id -u' to get the value.)"}
+: ${HOST_GROUP_ID?"Please set HOST_GROUP_ID environment variable. (Run 'id -g' to get the value.)"}
+
+RUN_AS_UID=${HOST_USER_ID:-9001}
+RUN_AS_GID=${HOST_GROUP_ID:-9001}
+
+RUN_AS_USER=${CONTAINER_USER_NAME:-defaultuser}
+RUN_AS_GROUP=${CONTAINER_GROUP_NAME:-defaultgroup}
+
+# Create a group/gid combination if it's not already present
+if getent group "$RUN_AS_GID" &> /dev/null; then
+    RUN_AS_GROUP=$(getent group "$RUN_AS_GID" | cut -d: -f1)
+else
+    groupadd -r "$RUN_AS_GROUP" --gid "$RUN_AS_GID"
+fi
+
+# Create a user/uid combination if it's not already present
+if id -u "$RUN_AS_UID" &> /dev/null; then
+    RUN_AS_USER=$(getent passwd "$RUN_AS_UID" | cut -d: -f1)
+else
+    useradd --shell /bin/bash --uid "$RUN_AS_UID" -c "" -m "$RUN_AS_USER"
+fi
+
+# Setup env var to switch the user
+export HOME="/home/$RUN_AS_USER"
+
+# This code path should not be hit easily. Print information if it arrives here.
+if [ "$RUN_AS_UID" -eq 9001 ] || [ "$RUN_AS_GID" -eq 9001 ]; then
+    cat <<-EOF
+
+	**********************************************************************************************
+	* You have not passed in either the HOST_USER_ID or the HOST_GROUP_ID environment variable.  *
+	* This could be because of some error or you are not using the Makefile helpers.             *
+	**********************************************************************************************
+	* As a result, all your files will be chowned by user:group=9001:9001                        *
+	* To fix this, run chown -R <user>:<group> ./ on the project directory on host OS.           *
+	* Hint: ls -lah \$HOME to figure out your <user>:<group>                                      *
+	**********************************************************************************************
+	* Check the Makefile and entrypoint.sh for more details                                      *
+	**********************************************************************************************
+
+	EOF
+fi
+
+# Own the file before switching the user
+chown -R "$RUN_AS_UID":"$RUN_AS_GID" /usr/src/app/
+
+# Print the user/uid - group/gid to start with
+cat <<EOF
+
+***************************************************************************
+Starting as : uid($RUN_AS_UID)$RUN_AS_USER | gid($RUN_AS_GID)$RUN_AS_GROUP
+***************************************************************************
+
+EOF
+
+# Switch to the user:group and exec
+exec /usr/local/bin/gosu "$RUN_AS_UID":"$RUN_AS_GID" "$@"

--- a/compose/web/requirements.txt
+++ b/compose/web/requirements.txt
@@ -1,0 +1,5 @@
+Django==1.9.10
+gunicorn==18.0
+wazimap[gdal]==0.7.3
+GDAL==2.1.3
+Shapely==1.5.17

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/wazimap_np/settings.py
+++ b/wazimap_np/settings.py
@@ -9,10 +9,13 @@ DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://wazimap_np:wazimap_n
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL)
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 
+SCHEME = 'https' if (os.environ.get('APP_ENV', 'dev') == 'prod') else 'http'
+URL = SCHEME+'://'+'www.nepalmap.org'
+
 # Localise this instance of Wazimap
 WAZIMAP['name'] = 'NepalMap'
 # NB: this must be https if your site supports HTTPS.
-WAZIMAP['url'] = 'http://www.nepalmap.org'
+WAZIMAP['url'] = URL
 WAZIMAP['country_code'] = 'NP'
 WAZIMAP['profile_builder'] = 'wazimap_np.profiles.get_census_profile'
 WAZIMAP['levels'] = {

--- a/wazimap_np/settings.py
+++ b/wazimap_np/settings.py
@@ -9,7 +9,7 @@ DATABASE_URL = os.environ.get('DATABASE_URL', 'postgresql://wazimap_np:wazimap_n
 DATABASES['default'] = dj_database_url.parse(DATABASE_URL)
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 
-SCHEME = 'https' if (os.environ.get('APP_ENV', 'dev') == 'prod') else 'http'
+SCHEME = 'http' if (os.environ.get('APP_ENV', 'dev') == 'dev') else 'https'
 URL = SCHEME+'://'+'www.nepalmap.org'
 
 # Localise this instance of Wazimap


### PR DESCRIPTION
I recently thought of jumping in and helping out with this project where possible. I use Docker and Docker Compose a lot, so I thought of starting out with building consistent environments. (as installing GADL is such a pain among others)

I have updated the Readme with instructions on usage. One can test out the staging environment locally as well.

No stress about having to merge/reject this right away. My intention is to start a discussion with a PR that works. 🍻 

Few things to note:
- Usage instructions add in Readme.
- I've included a separate `requirements.txt`, so that it wouldn't affect current requirements, but this can be sorted later.
- Staging can be tested out by running locally with the following changes in `compose.staging.yml`
```
# in caddy > environment
      - HOST_NAME=localhost
      - TLS_EMAIL=self_signed
# in caddy > ports
        - "2015:2015"

```
, and visiting `https://localhost:2015`