### PR TITLE
Suppress business section when no data present

### DIFF
--- a/wazimap_np/business.py
+++ b/wazimap_np/business.py
@@ -4,7 +4,7 @@ from wazimap.data.utils import get_stat_data
 
 
 def get_business_profile(geo_code, geo_level, session):
-    business_data = {}
+    business_data = {'area_has_data': False}
 
     if geo_level != 'vdc':
 
@@ -177,6 +177,8 @@ def get_business_profile(geo_code, geo_level, session):
              ('metadata', registered_non_profit_era_cats['metadata'])]
         )
         business_data = dict(
+         area_has_data=
+         True,
          is_vdc=
          False,
          registered_company_decade_distribution=

--- a/wazimap_np/templates/profile/sections/business.html
+++ b/wazimap_np/templates/profile/sections/business.html
@@ -1,7 +1,7 @@
 <article id="business" class="clearfix">
     {% if busness.area_has_data == False %}
         <h2>No data available for this area</h2>
-    {% else %}
+    {% elif disasters.area_has_data == True %}
         <header class="section-contents">
             <h1>Business</h1>
         </header>


### PR DESCRIPTION
VDCs and municipalities were displaying an empty "Business" section because we don't have business data at the local level. This PR suppresses the business section for VDCs and muncipalities.

Before:
![empty-vdc-biz-section](https://user-images.githubusercontent.com/3824492/33242396-07f5391e-d29a-11e7-9634-5b719fe139cb.png)


After:
![no-empty-biz-section](https://user-images.githubusercontent.com/3824492/33242397-0c6170c6-d29a-11e7-87e4-40f6e3235c39.png)
