### PR TITLE
remove "www" from the base url

### DIFF
--- a/wazimap_np/settings.py
+++ b/wazimap_np/settings.py
@@ -10,7 +10,7 @@ DATABASES['default'] = dj_database_url.parse(DATABASE_URL)
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 SCHEME = 'http' if (os.environ.get('APP_ENV', 'dev') == 'dev') else 'https'
-URL = SCHEME+'://'+'www.nepalmap.org'
+URL = SCHEME+'://'+'nepalmap.org'
 
 # Localise this instance of Wazimap
 WAZIMAP['name'] = 'NepalMap'


### PR DESCRIPTION
This is so that embedded iframes and the like use the base "nepalmap.org".

Currently, iframes will use "www.nepalmap.org" in the url. This simplifies it to just "nepalmap.org".