### PR TITLE
Remove requirements.txt copy used by Docker based setup (update the root requirements.txt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL:=help
-SHELL:=/bin/bash
+SHELL:=/usr/bin/env bash
 
 ifeq ($(APP_ENV),)
 $(error -- APP_ENV needs to be set, eg. APP_ENV=dev make)

--- a/compose/web/Dockerfile
+++ b/compose/web/Dockerfile
@@ -14,10 +14,7 @@ RUN set -exu \
     # gosu for easy step down from root
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
     && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
-
-    # make workdir
-    && mkdir -p /usr/src/app
+    && gosu nobody true
 
 WORKDIR /usr/src/app
 

--- a/compose/web/Dockerfile
+++ b/compose/web/Dockerfile
@@ -21,8 +21,8 @@ RUN set -exu \
 
 WORKDIR /usr/src/app
 
-COPY compose/web/requirements.txt /usr/src/app/requirements.txt
-RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt 
+COPY requirements.txt /usr/src/app/requirements.txt
+RUN pip install --no-cache-dir --global-option=build_ext --global-option="-I/usr/include/gdal/" -r requirements.txt
 
 COPY . /usr/src/app/
 

--- a/compose/web/requirements.txt
+++ b/compose/web/requirements.txt
@@ -1,5 +1,0 @@
-Django==1.9.10
-gunicorn==18.0
-wazimap[gdal]==0.7.3
-GDAL==2.1.3
-Shapely==1.5.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.9.10
 gunicorn==18.0
 wazimap[gdal]==0.7.3
-GDAL==1.11.2
+GDAL==2.1.3
 Shapely==1.5.17


### PR DESCRIPTION
When I first set out to docker-ize the project, I used a separate copy of `requirements.txt` so as to not affect the dependencies already being used, especially given was GDAL was quite a pain to install.

Now that Docker is being used in dev. as well as prod., I think it's time to clean that up, before I forget about it. That and some other tiny fixes.