### PR TITLE
Add data for eggs and egg layers

### DIFF
--- a/sql/agriculture_egg_layers.sql
+++ b/sql/agriculture_egg_layers.sql
@@ -1,0 +1,206 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+
+ALTER TABLE IF EXISTS ONLY public.agriculture_egg_layers DROP CONSTRAINT IF EXISTS agriculture_egg_layers_pkey;
+DROP TABLE IF EXISTS public.agriculture_egg_layers;
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: agriculture_egg_layers; Type: TABLE; Schema: public; Tablespace:
+--
+
+CREATE TABLE agriculture_egg_layers (
+    geo_level character varying(15) NOT NULL,
+    geo_code character varying(10) NOT NULL,
+    "egg layer type" character varying(128) NOT NULL,
+    total integer NOT NULL
+);
+
+
+--
+-- Data for Name: agriculture_egg_layers; Type: TABLE DATA; Schema: public
+--
+
+COPY agriculture_egg_layers (geo_code, geo_level, "egg layer type", total) FROM stdin WITH DELIMITER ',';
+NP,country,HENS,12353518
+NP,country,DUCKS,180927
+01,district,HENS,15366
+01,district,DUCKS,341
+02,district,HENS,63779
+02,district,DUCKS,261
+03,district,HENS,26781
+03,district,DUCKS,332
+04,district,HENS,199044
+04,district,DUCKS,3200
+05,district,HENS,77512
+05,district,DUCKS,465
+06,district,HENS,53957
+06,district,DUCKS,1136
+07,district,HENS,120878
+07,district,DUCKS,1400
+08,district,HENS,26030
+08,district,DUCKS,514
+09,district,HENS,336661
+09,district,DUCKS,25971
+10,district,HENS,204547
+10,district,DUCKS,7228
+11,district,HENS,42671
+11,district,DUCKS,374
+12,district,HENS,59344
+12,district,DUCKS,445
+13,district,HENS,50271
+13,district,DUCKS,354
+14,district,HENS,148326
+14,district,DUCKS,1474
+15,district,HENS,158952
+15,district,DUCKS,13498
+16,district,HENS,196437
+16,district,DUCKS,3200
+17,district,HENS,67464
+17,district,DUCKS,1964
+18,district,HENS,71247
+18,district,DUCKS,317
+19,district,HENS,102420
+19,district,DUCKS,2265
+20,district,HENS,103976
+20,district,DUCKS,3885
+21,district,HENS,121995
+21,district,DUCKS,3084
+22,district,HENS,211593
+22,district,DUCKS,4386
+23,district,HENS,151540
+23,district,DUCKS,1184
+24,district,HENS,780840
+24,district,DUCKS,1209
+25,district,HENS,385908
+25,district,DUCKS,2722
+26,district,HENS,267394
+26,district,DUCKS,1701
+27,district,HENS,514691
+27,district,DUCKS,2186
+28,district,HENS,13267
+28,district,DUCKS,275
+29,district,HENS,292757
+29,district,DUCKS,2824
+30,district,HENS,604699
+30,district,DUCKS,3576
+31,district,HENS,116105
+31,district,DUCKS,3651
+32,district,HENS,242429
+32,district,DUCKS,8244
+33,district,HENS,116045
+33,district,DUCKS,3476
+34,district,HENS,202947
+34,district,DUCKS,617
+35,district,HENS,2751238
+35,district,DUCKS,2006
+36,district,HENS,78538
+36,district,DUCKS,425
+37,district,HENS,47196
+37,district,DUCKS,381
+38,district,HENS,91121
+38,district,DUCKS,318
+39,district,HENS,2083
+39,district,DUCKS,10
+40,district,HENS,451830
+40,district,DUCKS,5226
+41,district,HENS,116948
+41,district,DUCKS,2888
+42,district,HENS,398655
+42,district,DUCKS,11550
+43,district,HENS,96610
+43,district,DUCKS,1790
+44,district,HENS,83033
+44,district,DUCKS,10848
+45,district,HENS,33577
+45,district,DUCKS,266
+46,district,HENS,77924
+46,district,DUCKS,118
+47,district,HENS,131159
+47,district,DUCKS,10412
+48,district,HENS,1488
+48,district,DUCKS,3
+49,district,HENS,32043
+49,district,DUCKS,501
+50,district,HENS,46229
+50,district,DUCKS,8150
+51,district,HENS,57523
+51,district,DUCKS,1370
+52,district,HENS,1706
+52,district,DUCKS,33
+53,district,HENS,5233
+53,district,DUCKS,33
+54,district,HENS,2605
+54,district,DUCKS,303
+55,district,HENS,8877
+55,district,DUCKS,86
+56,district,HENS,2835
+56,district,DUCKS,40
+57,district,HENS,75281
+57,district,DUCKS,1445
+58,district,HENS,40092
+58,district,DUCKS,91
+59,district,HENS,111477
+59,district,DUCKS,19
+60,district,HENS,411349
+60,district,DUCKS,3223
+61,district,HENS,24348
+61,district,DUCKS,757
+62,district,HENS,14589
+62,district,DUCKS,91
+63,district,HENS,43020
+63,district,DUCKS,313
+64,district,HENS,111258
+64,district,DUCKS,2028
+65,district,HENS,194508
+65,district,DUCKS,858
+66,district,HENS,123536
+66,district,DUCKS,1214
+67,district,HENS,9844
+67,district,DUCKS,198
+68,district,HENS,12096
+68,district,DUCKS,143
+69,district,HENS,8917
+69,district,DUCKS,188
+70,district,HENS,22999
+70,district,DUCKS,80
+71,district,HENS,277409
+71,district,DUCKS,3418
+72,district,HENS,6723
+72,district,DUCKS,101
+73,district,HENS,3509
+73,district,DUCKS,107
+74,district,HENS,10131
+74,district,DUCKS,205
+75,district,HENS,186108
+75,district,DUCKS,1932
+\.
+
+
+--
+-- Name: agriculture_egg_layers_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
+--
+
+ALTER TABLE ONLY agriculture_egg_layers
+    ADD CONSTRAINT agriculture_egg_layers_pkey PRIMARY KEY (geo_level, geo_code, "egg layer type");
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/sql/agriculture_eggs.sql
+++ b/sql/agriculture_eggs.sql
@@ -1,0 +1,206 @@
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+
+ALTER TABLE IF EXISTS ONLY public.agriculture_eggs DROP CONSTRAINT IF EXISTS agriculture_eggs_pkey;
+DROP TABLE IF EXISTS public.agriculture_eggs;
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: agriculture_eggs; Type: TABLE; Schema: public; Tablespace:
+--
+
+CREATE TABLE agriculture_eggs (
+    geo_level character varying(15) NOT NULL,
+    geo_code character varying(10) NOT NULL,
+    "egg type" character varying(128) NOT NULL,
+    total integer NOT NULL
+);
+
+
+--
+-- Data for Name: agriculture_eggs; Type: TABLE DATA; Schema: public
+--
+
+COPY agriculture_eggs (geo_code, geo_level, "egg type", total) FROM stdin WITH DELIMITER ',';
+NP,country,HEN_EGGS,1294166000
+NP,country,DUCK_EGGS,13906000
+01,district,HEN_EGGS,2420000
+01,district,DUCK_EGGS,25000
+02,district,HEN_EGGS,5581000
+02,district,DUCK_EGGS,19000
+03,district,HEN_EGGS,6656000
+03,district,DUCK_EGGS,27000
+04,district,HEN_EGGS,28610000
+04,district,DUCK_EGGS,258000
+05,district,HEN_EGGS,5506000
+05,district,DUCK_EGGS,34000
+06,district,HEN_EGGS,4037000
+06,district,DUCK_EGGS,88000
+07,district,HEN_EGGS,1878000
+07,district,DUCK_EGGS,109000
+08,district,HEN_EGGS,3000000
+08,district,DUCK_EGGS,39000
+09,district,HEN_EGGS,31600000
+09,district,DUCK_EGGS,2052000
+10,district,HEN_EGGS,29569000
+10,district,DUCK_EGGS,549000
+11,district,HEN_EGGS,2345000
+11,district,DUCK_EGGS,28000
+12,district,HEN_EGGS,3296000
+12,district,DUCK_EGGS,33000
+13,district,HEN_EGGS,4310000
+13,district,DUCK_EGGS,27000
+14,district,HEN_EGGS,50120000
+14,district,DUCK_EGGS,116000
+15,district,HEN_EGGS,18082000
+15,district,DUCK_EGGS,1060000
+16,district,HEN_EGGS,17231000
+16,district,DUCK_EGGS,248000
+17,district,HEN_EGGS,8040000
+17,district,DUCK_EGGS,155000
+18,district,HEN_EGGS,6502000
+18,district,DUCK_EGGS,24000
+19,district,HEN_EGGS,7683000
+19,district,DUCK_EGGS,175000
+20,district,HEN_EGGS,8650000
+20,district,DUCK_EGGS,295000
+21,district,HEN_EGGS,9850000
+21,district,DUCK_EGGS,234000
+22,district,HEN_EGGS,5498000
+22,district,DUCK_EGGS,333000
+23,district,HEN_EGGS,7500000
+23,district,DUCK_EGGS,90000
+24,district,HEN_EGGS,35896000
+24,district,DUCK_EGGS,92000
+25,district,HEN_EGGS,40781000
+25,district,DUCK_EGGS,214000
+26,district,HEN_EGGS,32115000
+26,district,DUCK_EGGS,131000
+27,district,HEN_EGGS,41065000
+27,district,DUCK_EGGS,168000
+28,district,HEN_EGGS,942000
+28,district,DUCK_EGGS,20000
+29,district,HEN_EGGS,26109000
+29,district,DUCK_EGGS,215000
+30,district,HEN_EGGS,28205000
+30,district,DUCK_EGGS,272000
+31,district,HEN_EGGS,7822000
+31,district,DUCK_EGGS,277000
+32,district,HEN_EGGS,9955000
+32,district,DUCK_EGGS,627000
+33,district,HEN_EGGS,10210000
+33,district,DUCK_EGGS,264000
+34,district,HEN_EGGS,58059000
+34,district,DUCK_EGGS,47000
+35,district,HEN_EGGS,411901000
+35,district,DUCK_EGGS,274000
+36,district,HEN_EGGS,4598000
+36,district,DUCK_EGGS,32000
+37,district,HEN_EGGS,7433000
+37,district,DUCK_EGGS,29000
+38,district,HEN_EGGS,14352000
+38,district,DUCK_EGGS,24000
+39,district,HEN_EGGS,210000
+39,district,DUCK_EGGS,1000
+40,district,HEN_EGGS,42827000
+40,district,DUCK_EGGS,324000
+41,district,HEN_EGGS,5846000
+41,district,DUCK_EGGS,219000
+42,district,HEN_EGGS,41068000
+42,district,DUCK_EGGS,878000
+43,district,HEN_EGGS,9004000
+43,district,DUCK_EGGS,136000
+44,district,HEN_EGGS,9758000
+44,district,DUCK_EGGS,824000
+45,district,HEN_EGGS,3837000
+45,district,DUCK_EGGS,20000
+46,district,HEN_EGGS,7289000
+46,district,DUCK_EGGS,7000
+47,district,HEN_EGGS,4898000
+47,district,DUCK_EGGS,802000
+48,district,HEN_EGGS,406000
+48,district,DUCK_EGGS,0
+49,district,HEN_EGGS,3081000
+49,district,DUCK_EGGS,38000
+50,district,HEN_EGGS,6252000
+50,district,DUCK_EGGS,525000
+51,district,HEN_EGGS,2199000
+51,district,DUCK_EGGS,104000
+52,district,HEN_EGGS,269000
+52,district,DUCK_EGGS,2000
+53,district,HEN_EGGS,601000
+53,district,DUCK_EGGS,2000
+54,district,HEN_EGGS,450000
+54,district,DUCK_EGGS,21000
+55,district,HEN_EGGS,602000
+55,district,DUCK_EGGS,7000
+56,district,HEN_EGGS,446000
+56,district,DUCK_EGGS,2000
+57,district,HEN_EGGS,2872000
+57,district,DUCK_EGGS,110000
+58,district,HEN_EGGS,3315000
+58,district,DUCK_EGGS,7000
+59,district,HEN_EGGS,4025000
+59,district,DUCK_EGGS,1000
+60,district,HEN_EGGS,54787000
+60,district,DUCK_EGGS,260000
+61,district,HEN_EGGS,3855000
+61,district,DUCK_EGGS,58000
+62,district,HEN_EGGS,2298000
+62,district,DUCK_EGGS,5000
+63,district,HEN_EGGS,6776000
+63,district,DUCK_EGGS,26000
+64,district,HEN_EGGS,10525000
+64,district,DUCK_EGGS,162000
+65,district,HEN_EGGS,13063000
+65,district,DUCK_EGGS,65000
+66,district,HEN_EGGS,15457000
+66,district,DUCK_EGGS,92000
+67,district,HEN_EGGS,852000
+67,district,DUCK_EGGS,15000
+68,district,HEN_EGGS,1905000
+68,district,DUCK_EGGS,9000
+69,district,HEN_EGGS,985000
+69,district,DUCK_EGGS,14000
+70,district,HEN_EGGS,3622000
+70,district,DUCK_EGGS,7000
+71,district,HEN_EGGS,16928000
+71,district,DUCK_EGGS,275000
+72,district,HEN_EGGS,778000
+72,district,DUCK_EGGS,6000
+73,district,HEN_EGGS,594000
+73,district,DUCK_EGGS,6000
+74,district,HEN_EGGS,1596000
+74,district,DUCK_EGGS,17000
+75,district,HEN_EGGS,13483000
+75,district,DUCK_EGGS,155000
+\.
+
+
+--
+-- Name: agriculture_eggs_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
+--
+
+ALTER TABLE ONLY agriculture_eggs
+    ADD CONSTRAINT agriculture_eggs_pkey PRIMARY KEY (geo_level, geo_code, "egg type");
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/wazimap_np/agriculture.py
+++ b/wazimap_np/agriculture.py
@@ -22,7 +22,7 @@ LIVESTOCK_RECODES = OrderedDict([
 ])
 
 MILK_ANIMAL_RECODES = OrderedDict([
-    ('BUFFALOES', 'Water Buffalo'),
+    ('BUFFALOES', 'Water Buffaloes'),
     ('COWS', 'Cows')
 ])
 

--- a/wazimap_np/agriculture.py
+++ b/wazimap_np/agriculture.py
@@ -31,6 +31,16 @@ MILK_RECODES = OrderedDict([
     ('COW_MILK', 'Cow Milk')
 ])
 
+EGG_RECODES = OrderedDict([
+    ('HEN_EGGS', 'Hen Eggs'),
+    ('DUCK_EGGS', 'Duck Eggs')
+])
+
+EGG_LAYER_RECODES = OrderedDict([
+    ('HENS', 'Hens'),
+    ('DUCKS', 'Ducks')
+])
+
 
 def get_agriculture_profile(geo_code, geo_level, session):
     agriculture_data = {'area_has_data': False}
@@ -61,6 +71,18 @@ def get_agriculture_profile(geo_code, geo_level, session):
             percent=False,
             order_by='-total')
 
+        egg_dist, total_eggs = get_stat_data(
+            'egg type', geo_level, geo_code, session,
+            recode=dict(EGG_RECODES),
+            percent=False,
+            order_by='-total')
+
+        egg_layer_dist, total_egg_layers = get_stat_data(
+            'egg layer type', geo_level, geo_code, session,
+            recode=dict(EGG_LAYER_RECODES),
+            percent=False,
+            order_by='-total')
+
         agriculture_data = dict(
             is_vdc=False,
             area_has_data=True,
@@ -83,6 +105,16 @@ def get_agriculture_profile(geo_code, geo_level, session):
             total_milk={
                 'name': 'Metric tons of milk',
                 'values': {'this': total_milk}
+            },
+            egg_distribution=egg_dist,
+            total_eggs={
+                'name': 'Number of eggs',
+                'values': {'this': total_eggs}
+            },
+            egg_layer_distribution=egg_layer_dist,
+            total_egg_layers={
+                'name': 'Number of laying hens and ducks',
+                'values': {'this': total_egg_layers}
             },
         )
 

--- a/wazimap_np/tables.py
+++ b/wazimap_np/tables.py
@@ -267,6 +267,24 @@ FieldTable(['milk animal type'],
            year='2016',
            table_per_level=False)
 
+# eggs
+FieldTable(['egg type'],
+           id='agriculture_eggs',
+           universe='eggs',
+           description='Number of eggs produced annually',
+           dataset='Statistical Information on Nepalese Agriculture',
+           year='2016',
+           table_per_level=False)
+
+# egg layers
+FieldTable(['egg layer type'],
+           id='agriculture_egg_layers',
+           universe='egg layers',
+           description='Number of egg laying hens and ducks',
+           dataset='Statistical Information on Nepalese Agriculture',
+           year='2016',
+           table_per_level=False)
+
 # Simple Tables
 SimpleTable(
     id='lifeexpectancy',

--- a/wazimap_np/templates/profile/sections/agriculture.html
+++ b/wazimap_np/templates/profile/sections/agriculture.html
@@ -80,6 +80,45 @@
                         Nepalese Agriculture 2072/73</a> (PDF)
                     <br>
                 </small>
+            </section>
+            <section class="clearfix stat-row">
+                <h2><a class="permalink" href="#agriculture-total-egg-layers"
+                       id="agriculture-total-egg-layers">Laying Hens and Ducks
+                    <i class="fa fa-link"></i></a></h2>
+                <div class="column-third">
+                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_egg_layers stat_type='number' %}
+                </div>
+                <div class="column-two-thirds"
+                     id="chart-histogram-agriculture-egg_layer_distribution"
+                     data-stat-type="number"
+                     data-chart-title="Number of laying hens and ducks"></div>
+                <small>Source: <br>
+                    <a target="_blank"
+                       href="http://moad.gov.np/public/uploads/1142453195-STATISTIC%20AGRICULTURE%20BOOK_2016.pdf">Ministry
+                        of Agricultural Development Statistical Information on
+                        Nepalese Agriculture 2072/73</a> (PDF)
+                    <br>
+                </small>
+            </section>
+            <section class="clearfix stat-row">
+                <h2><a class="permalink" href="#agriculture-total-eggs"
+                       id="agriculture-total-eggs">Egg Production
+                    <i class="fa fa-link"></i></a></h2>
+                <div class="column-third">
+                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_eggs stat_type='number' %}
+                </div>
+                <div class="column-two-thirds"
+                     id="chart-histogram-agriculture-egg_distribution"
+                     data-stat-type="number"
+                     data-chart-title="Number of eggs produced"></div>
+                <small>Source: <br>
+                    <a target="_blank"
+                       href="http://moad.gov.np/public/uploads/1142453195-STATISTIC%20AGRICULTURE%20BOOK_2016.pdf">Ministry
+                        of Agricultural Development Statistical Information on
+                        Nepalese Agriculture 2072/73</a> (PDF)
+                    <br>
+                </small>
+            </section>
         </div>
     {% endif %}
 </article>

--- a/wazimap_np/templates/profile/sections/agriculture.html
+++ b/wazimap_np/templates/profile/sections/agriculture.html
@@ -42,15 +42,21 @@
                     <br>
                 </small>
             </section>
-            </section>
             <section class="clearfix stat-row">
                 <h2><a class="permalink" href="#agriculture-total-milk-animals"
-                       id="agriculture-total-milk-animals">Milk Animals
+                       id="agriculture-total-milk-animals">Milk Production and Milk Animals
                     <i class="fa fa-link"></i></a></h2>
-                <div class="column-third">
+                <div class="column-quarter">
+                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_milk stat_type='number' %}
+                </div>
+                <div class="column-quarter"
+                     id="chart-histogram-agriculture-milk_distribution"
+                     data-stat-type="number"
+                     data-chart-title="Metric tons of milk produced annually"></div>
+                <div class="column-quarter">
                     {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_milk_animals stat_type='number' %}
                 </div>
-                <div class="column-two-thirds"
+                <div class="column-quarter"
                      id="chart-histogram-agriculture-milk_animal_distribution"
                      data-stat-type="number"
                      data-chart-title="Number of milk animals"></div>
@@ -63,54 +69,23 @@
                 </small>
             </section>
             <section class="clearfix stat-row">
-                <h2><a class="permalink" href="#agriculture-total-milk"
-                       id="agriculture-total-milk">Milk Production
+                <h2><a class="permalink" href="#agriculture-egg-production"
+                       id="agriculture-egg-production">Egg Production
                     <i class="fa fa-link"></i></a></h2>
-                <div class="column-third">
-                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_milk stat_type='number' %}
+                <div class="column-quarter">
+                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_eggs stat_type='number' %}
                 </div>
-                <div class="column-two-thirds"
-                     id="chart-histogram-agriculture-milk_distribution"
+                <div class="column-quarter"
+                     id="chart-histogram-agriculture-egg_distribution"
                      data-stat-type="number"
-                     data-chart-title="Metric tons of milk produced"></div>
-                <small>Source: <br>
-                    <a target="_blank"
-                       href="http://moad.gov.np/public/uploads/1142453195-STATISTIC%20AGRICULTURE%20BOOK_2016.pdf">Ministry
-                        of Agricultural Development Statistical Information on
-                        Nepalese Agriculture 2072/73</a> (PDF)
-                    <br>
-                </small>
-            </section>
-            <section class="clearfix stat-row">
-                <h2><a class="permalink" href="#agriculture-total-egg-layers"
-                       id="agriculture-total-egg-layers">Laying Hens and Ducks
-                    <i class="fa fa-link"></i></a></h2>
-                <div class="column-third">
+                     data-chart-title="Number of eggs produced annually"></div>
+                <div class="column-quarter">
                     {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_egg_layers stat_type='number' %}
                 </div>
-                <div class="column-two-thirds"
+                <div class="column-quarter"
                      id="chart-histogram-agriculture-egg_layer_distribution"
                      data-stat-type="number"
                      data-chart-title="Number of laying hens and ducks"></div>
-                <small>Source: <br>
-                    <a target="_blank"
-                       href="http://moad.gov.np/public/uploads/1142453195-STATISTIC%20AGRICULTURE%20BOOK_2016.pdf">Ministry
-                        of Agricultural Development Statistical Information on
-                        Nepalese Agriculture 2072/73</a> (PDF)
-                    <br>
-                </small>
-            </section>
-            <section class="clearfix stat-row">
-                <h2><a class="permalink" href="#agriculture-total-eggs"
-                       id="agriculture-total-eggs">Egg Production
-                    <i class="fa fa-link"></i></a></h2>
-                <div class="column-third">
-                    {% include 'profile/_blocks/_stat_list.html' with stat=agriculture.total_eggs stat_type='number' %}
-                </div>
-                <div class="column-two-thirds"
-                     id="chart-histogram-agriculture-egg_distribution"
-                     data-stat-type="number"
-                     data-chart-title="Number of eggs produced"></div>
                 <small>Source: <br>
                     <a target="_blank"
                        href="http://moad.gov.np/public/uploads/1142453195-STATISTIC%20AGRICULTURE%20BOOK_2016.pdf">Ministry


### PR DESCRIPTION
Adds data for eggs and egg layers. 

Data source:
https://github.com/Code4Nepal/data/blob/master/datasets/agriculture/Egg%20Production.csv

Note that unit for eggs is 1000 in the data set. For example, "25" for Taplejung means 25,000.

Also re-formats milk and milk animals to take up one row instead of two. Since there are only two types of milk animals reported (water buffaloes and cows), it looks better to have one row that contains both milk production as well as the number of milk animals. The same layout is adopted for eggs since there are only two types of egg layers reported (hens and ducks).

Eggs and egg layers in Kailali:
![milk-and-eggs-kailali](https://user-images.githubusercontent.com/3824492/41508874-1aaaffa0-7211-11e8-9842-cf930e21beae.png)


Eggs and egg layers in Nepal:
![milk-and-eggs-nepal](https://user-images.githubusercontent.com/3824492/41508878-20dee1ca-7211-11e8-9682-7c93fa4a9dd3.png)
