### PR TITLE
Pin whitenoise dependencies to 3.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn==19.5.0
 wazimap[gdal]==0.8.2
 GDAL==2.1.3
 Shapely==1.5.17
+whitenoise==3.3.1


### PR DESCRIPTION
whitenoise version 4.0 introduces breaking changes (see http://whitenoise.evans.io/en/stable/changelog.html#v4-0), and the wazimap framework will
need to be upgraded to handle that change. There is a pull request open
for that. See https://github.com/OpenUpSA/wazimap/pull/133

Until that is merged (and nepalmap is upgraded to a version that
includes that change, this pins the whitenoise dependency to 3.3.1.

This is required to allow previous updates to work correctly.