### PR TITLE
Terminate education data copy command, add primary keys

### DIFF
--- a/sql/highersecondarylevel-schools.sql
+++ b/sql/highersecondarylevel-schools.sql
@@ -190,3 +190,4 @@ district,260,Community schools,74
 district,32,Institutional schools,74
 district,293,Community schools,75
 district,164,Institutional schools,75
+\.

--- a/sql/highersecondarylevel-schools.sql
+++ b/sql/highersecondarylevel-schools.sql
@@ -191,3 +191,10 @@ district,32,Institutional schools,74
 district,293,Community schools,75
 district,164,Institutional schools,75
 \.
+
+--
+-- Name: education_teachers_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
+--
+
+ALTER TABLE ONLY education_schools
+    ADD CONSTRAINT education_schools_pkey PRIMARY KEY (geo_level, geo_code, "school type");

--- a/sql/secondarylevel-teachers.sql
+++ b/sql/secondarylevel-teachers.sql
@@ -193,3 +193,10 @@ district,360,Rahat teachers,74
 district,1217,Approved teachers,75
 district,705,Rahat teachers,75
 \.
+
+--
+-- Name: education_teachers_pkey; Type: CONSTRAINT; Schema: public; Tablespace:
+--
+
+ALTER TABLE ONLY education_teachers
+    ADD CONSTRAINT education_teachers_pkey PRIMARY KEY (geo_level, geo_code, "teacher type");

--- a/sql/secondarylevel-teachers.sql
+++ b/sql/secondarylevel-teachers.sql
@@ -192,3 +192,4 @@ district,847,Approved teachers,74
 district,360,Rahat teachers,74
 district,1217,Approved teachers,75
 district,705,Rahat teachers,75
+\.


### PR DESCRIPTION
Add a line that includes `\.` at the end of the copy command

Add primary keys to the education data tables
