### PR TITLE
Pin django-cors-headers and SQLAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ wazimap[gdal]==0.8.2
 GDAL==2.1.3
 Shapely==1.5.17
 whitenoise==3.3.1
+SQLAlchemy==1.2.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.9.10
+django-cors-headers==2.4.1
 gunicorn==19.5.0
 wazimap[gdal]==0.8.2
 GDAL==2.1.3


### PR DESCRIPTION
Pins django-cors-headers to 2.4.1 because later versions require a newer version of Django, and wazimap does not run on a newer version of Django.

Pins SQLAlchemy to 1.2.19 to match https://github.com/Code4Nepal/nepalmap_federal/commit/7f3994ea03e3882fe4fc452b0d2a2921b346db36 (committed by @amitness)