### PR TITLE
Update Caddy to 0.11.5

### DIFF
--- a/compose/caddy/Dockerfile
+++ b/compose/caddy/Dockerfile
@@ -1,3 +1,3 @@
-FROM abiosoft/caddy:0.10.12
+FROM abiosoft/caddy:0.11.5
 
 RUN apk add --no-cache bash


### PR DESCRIPTION
This is identical to the nepalmap_federal commit at
https://github.com/Code4Nepal/nepalmap_federal/pull/87/commits/57d4f189ae59bc27734769b512346c277e2b5dbb

Prior to the update, starting caddy generates this error:
```
caddy_1     | Activating privacy features... 2020/02/09 16:54:10 [INFO][2011.nepalmap.org] acme: Obtaining bundled SAN certificate
caddy_1     | 2020/02/09 16:54:10 [INFO][2011.nepalmap.org] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/38020288
caddy_1     | 2020/02/09 16:54:10 [] failed to get certificate: acme: Error 405 - urn:ietf:params:acme:error:malformed - Method not allowed
```